### PR TITLE
New Role: Replicant, New Ability: Replicator

### DIFF
--- a/VVUP.CustomRoles/Abilities/Active/Replicator.cs
+++ b/VVUP.CustomRoles/Abilities/Active/Replicator.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using Exiled.API.Features;
+using Exiled.API.Features.Attributes;
+using Exiled.CustomRoles.API.Features;
+using Exiled.Events.EventArgs.Player;
+using UnityEngine;
+
+namespace VVUP.CustomRoles.Abilities.Active
+{
+    [CustomAbility]
+    public class Replicator : ActiveAbility
+    {
+        public override string Name { get; set; } = "Replicator";
+        public override string Description { get; set; } = "Create Decoy and make Recon";
+        public override float Duration { get; set; } = 15f;
+        public override float Cooldown { get; set; } = 45f;
+        public string EndedMessage { get; set; } = "<color=red>Replicator Expired</color>";
+        public string KilledDecoy { get; set; } = "Your decoy has been killed!";
+
+        private readonly Dictionary<Player, Npc> decoys = new();
+        private readonly Dictionary<Player, Vector3> startPos = new();
+
+        protected override void AbilityUsed(Player player)
+        {
+            startPos[player] = player.Position;
+
+            Npc dummy = Npc.Spawn(player.Nickname, player.Role.Type, player.Position);
+            dummy.CustomInfo = player.CustomInfo;
+            decoys[player] = dummy;
+
+            Exiled.Events.Handlers.Player.Hurting += OnPlayerHurting;
+            Exiled.Events.Handlers.Player.Shooting += OnPlayerShooting;
+            Exiled.Events.Handlers.Player.UsingItem += OnPlayerUsingItem;
+            Exiled.Events.Handlers.Player.Dying += OnDummyDying;
+        }
+
+        protected override void AbilityEnded(Player player)
+        {
+            if (decoys.TryGetValue(player, out Npc dummy))
+            {
+                player.Position = dummy.Position;
+                dummy.Destroy();
+            }
+
+            decoys.Remove(player);
+            startPos.Remove(player);
+
+            Exiled.Events.Handlers.Player.Hurting -= OnPlayerHurting;
+            Exiled.Events.Handlers.Player.Shooting -= OnPlayerShooting;
+            Exiled.Events.Handlers.Player.UsingItem -= OnPlayerUsingItem;
+            Exiled.Events.Handlers.Player.Dying -= OnDummyDying;
+        }
+
+        private void OnPlayerHurting(HurtingEventArgs ev)
+        {
+            if (decoys.ContainsKey(ev.Player))
+            {
+                ev.IsAllowed = false;
+                EndAbility(ev.Player);
+            }
+        }
+
+        private void OnPlayerShooting(ShootingEventArgs ev)
+        {
+            if (decoys.ContainsKey(ev.Player))
+                ev.IsAllowed = false;
+        }
+
+        private void OnPlayerUsingItem(UsingItemEventArgs ev)
+        {
+            if (decoys.ContainsKey(ev.Player))
+                ev.IsAllowed = false;
+        }
+
+        private void OnDummyDying(DyingEventArgs ev)
+        {
+            foreach (var kvp in decoys)
+            {
+                if (kvp.Value != null && kvp.Value.ReferenceHub == ev.Player.ReferenceHub)
+                {
+                    kvp.Key.Kill(KilledDecoy);
+                    EndAbility(kvp.Key);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/VVUP.CustomRoles/Config.cs
+++ b/VVUP.CustomRoles/Config.cs
@@ -19,6 +19,7 @@ namespace VVUP.CustomRoles
         public int ReviveMistId { get; set; } = 10007;
         public int TeleportId { get; set; } = 10008;
         public int SoundBreakerId { get; set; } = 10009;
+        public int ReplicatorId { get; set; } = 10010;
         public int CustomRoleTextId { get; set; } = 2;
         public string ActiveCamoHint { get; set; } = "Press the keybind to activate Active Camo, you will become invisible for a short time (Custom Ability).";
         public string ChargeHint { get; set; } = "Press the keybind to activate Charge, you will be able to charge at a target (Custom Ability).";
@@ -29,6 +30,7 @@ namespace VVUP.CustomRoles
         public string ReviveMistHint { get; set; } = "Press the keybind to activate Revive Mist, you will be able to revive nearby players (Custom Ability).";
         public string TeleportHint { get; set; } = "Press the keybind to activate Teleport, you will be able to teleport to a target location (Custom Ability).";
         public string SoundBreakerHint { get; set; } = "Press the keybind to reset Blink cooldown and reduce the next blink interval and distance (Custom Ability).";
+        public string ReplicatorHint { get; set; } = "Press the keybind to create Decoy and make safe Recon (Custom Ability).";
         public string ActiveCamoSsssText { get; set; } = "Active Camo";
         public string ChargeSsssText { get; set; } = "Charge";
         public string DetectSsssText { get; set; } = "Detect";
@@ -38,6 +40,7 @@ namespace VVUP.CustomRoles
         public string ReviveMistSsssText { get; set; } = "Reviving Mist";
         public string TeleportSsssText { get; set; } = "Teleport";
         public string SoundBreakerSsssText { get; set; } = "Sound Breaker";
+        public string ReplicatorSsssText { get; set; } = "Replicator";
         public string SsssActiveCamoActivationMessage { get; set; } = "Activated Active Camo";
         public string SsssChargeActivationMessage { get; set; } = "Activated Charge";
         public string SsssDoorPickingActivationMessage { get; set; } = "Activated Door Picking, Interact with the door you want to pick.";
@@ -46,5 +49,6 @@ namespace VVUP.CustomRoles
         //public string SsssReviveMistActivationMessage { get; set; } = "Activated Revive Mist";
         public string SsssTeleportActivationMessage { get; set; } = "Activated Teleport";
         public string SsssSoundBreakerActivationMessage { get; set; } = "Activated Sound Breaker";
+        public string SsssReplicatorActivationMessage { get; set; } = "Activated Replicator";
     }
 }

--- a/VVUP.CustomRoles/CustomRolesConfig.cs
+++ b/VVUP.CustomRoles/CustomRolesConfig.cs
@@ -135,5 +135,10 @@ namespace VVUP.CustomRoles
         {
             new SoundBreaker173()
         };
+
+        public List<Replicant> Replicant { get; set; } = new()
+        {
+            new Replicant()
+        };
     }
 }

--- a/VVUP.CustomRoles/Plugin.cs
+++ b/VVUP.CustomRoles/Plugin.cs
@@ -70,6 +70,7 @@ namespace VVUP.CustomRoles
             Config.CustomRolesConfig.SpeedsterZombies.Register();
             Config.CustomRolesConfig.TeleportZombies.Register();
             Config.CustomRolesConfig.SoundBreaker173.Register();
+            Config.CustomRolesConfig.Replicant.Register();
 
             foreach (CustomRole role in CustomRole.Registered)
             {

--- a/VVUP.CustomRoles/Roles/Chaos/Replicant.cs
+++ b/VVUP.CustomRoles/Roles/Chaos/Replicant.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using Exiled.API.Features.Attributes;
+using Exiled.API.Features.Spawn;
+using Exiled.CustomRoles.API.Features;
+using PlayerRoles;
+using VVUP.CustomRoles.Abilities.Active;
+using VVUP.CustomRoles.API;
+
+namespace VVUP.CustomRoles.Roles.Chaos
+{
+    [CustomRole(RoleTypeId.ChaosRifleman)]
+    public class Replicant : CustomRole, ICustomRole
+    {
+        public int Chance { get; set; } = 5;
+        public override uint Id { get; set; } = 59;
+        public override int MaxHealth { get; set; } = 100;
+        public override string Name { get; set; } = "<color=#008f1e>Chaos Replicant</color>";
+        public override string Description { get; set; } = "A Chaos Insurgent that can create decoy and make recon";
+        public override string CustomInfo { get; set; } = "Chaos Replicant";
+        public override RoleTypeId Role { get; set; } = RoleTypeId.ChaosRifleman;
+        public StartTeam StartTeam { get; set; } = StartTeam.Chaos;
+        public override SpawnProperties SpawnProperties { get; set; } = new()
+        {
+            Limit = 1,
+            RoleSpawnPoints = new List<RoleSpawnPoint>
+            {
+                new()
+                {
+                    Role = RoleTypeId.ChaosRifleman,
+                    Chance = 100,
+                },
+            },
+        };
+
+        public override List<CustomAbility> CustomAbilities { get; set; } = new List<CustomAbility>
+        {
+            new Replicator
+            {
+                Name = "Replicator [Active]",
+                Description = "Create decoy and make recon",
+            },
+        };
+        
+        public override string AbilityUsage { get; set; } = "Use your Replicator ability with your server keybind (set it in ESC > Settings > Server Settings).";
+    }
+}

--- a/VVUP.CustomRoles/Ssss.cs
+++ b/VVUP.CustomRoles/Ssss.cs
@@ -52,6 +52,7 @@ namespace VVUP.CustomRoles
                 TheoreticalPhysicistScientist.Get(typeof(TheoreticalPhysicistScientist)),
                 Vanguard.Get(typeof(Vanguard)),
                 SoundBreaker173.Get(typeof(SoundBreaker173)),
+                Replicant.Get(typeof(Replicant)),
             };
                 
             foreach (var role in customRoles)
@@ -78,6 +79,7 @@ namespace VVUP.CustomRoles
              settings.Add(new SSKeybindSetting(Plugin.Instance.Config.ReviveMistId, Plugin.Instance.Config.ReviveMistSsssText, KeyCode.B, true, false, Plugin.Instance.Config.ReviveMistHint));
              settings.Add(new SSKeybindSetting(Plugin.Instance.Config.TeleportId, Plugin.Instance.Config.TeleportSsssText, KeyCode.B, true, false, Plugin.Instance.Config.TeleportHint));
              settings.Add(new SSKeybindSetting(Plugin.Instance.Config.SoundBreakerId, Plugin.Instance.Config.SoundBreakerSsssText,KeyCode.C, true, false, Plugin.Instance.Config.SoundBreakerHint));
+             settings.Add(new SSKeybindSetting(Plugin.Instance.Config.ReplicatorId, Plugin.Instance.Config.ReplicatorSsssText,KeyCode.P, true, false, Plugin.Instance.Config.ReplicatorHint));
             return settings.ToArray();
         }
         public static void SafeAppendSsssSettings()

--- a/VVUP.CustomRoles/SsssEventHandlers.cs
+++ b/VVUP.CustomRoles/SsssEventHandlers.cs
@@ -40,7 +40,8 @@ namespace VVUP.CustomRoles
                      || ssKeybindSetting.SettingId == Plugin.Instance.Config.RemoveDisguiseId
                      || ssKeybindSetting.SettingId == Plugin.Instance.Config.ReviveMistId
                      || ssKeybindSetting.SettingId == Plugin.Instance.Config.TeleportId
-                     || ssKeybindSetting.SettingId == Plugin.Instance.Config.SoundBreakerId)
+                     || ssKeybindSetting.SettingId == Plugin.Instance.Config.SoundBreakerId
+                     || ssKeybindSetting.SettingId == Plugin.Instance.Config.ReplicatorId)
 
                     && ActiveAbility.AllActiveAbilities.TryGetValue(player, out var abilities))
                 {
@@ -173,6 +174,20 @@ namespace VVUP.CustomRoles
                             soundBreakerAbility.SelectAbility(player);
                             soundBreakerAbility.UseAbility(player);
                             player.ShowHint(Plugin.Instance.Config.SsssSoundBreakerActivationMessage);
+                        }
+                        else
+                        {
+                            player.ShowHint(response);
+                        }
+                    }
+                    else if (ssKeybindSetting.SettingId == Plugin.Instance.Config.ReplicatorId)
+                    {
+                        var replicatorAbility = abilities.FirstOrDefault(abilities => abilities.GetType() == typeof(Replicator));
+                        if (replicatorAbility != null && replicatorAbility.CanUseAbility(player, out response))
+                        {
+                            replicatorAbility.SelectAbility(player);
+                            replicatorAbility.UseAbility(player);
+                            player.ShowHint(Plugin.Instance.Config.SsssReplicatorActivationMessage);
                         }
                         else
                         {

--- a/VVUP.CustomRoles/VVUP.CustomRoles.csproj
+++ b/VVUP.CustomRoles/VVUP.CustomRoles.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Abilities\Active\HealingMist.cs" />
     <Compile Include="Abilities\Active\RemoveDisguise.cs" />
     <Compile Include="Abilities\Active\RevivingMist.cs" />
+    <Compile Include="Abilities\Active\Replicator.cs" />
     <Compile Include="Abilities\Active\SoundBreaker.cs" />
     <Compile Include="Abilities\Active\Teleport.cs" />
     <Compile Include="Abilities\Passive\AbilityRemover.cs" />
@@ -142,6 +143,7 @@
     <Compile Include="Plugin.cs" />
     <Compile Include="Roles\Chaos\A7Chaos.cs" />
     <Compile Include="Roles\Chaos\CiPhantom.cs" />
+    <Compile Include="Roles\Chaos\Replicant.cs" />
     <Compile Include="Roles\Chaos\CISpy.cs" />
     <Compile Include="Roles\Chaos\JuggernautChaos.cs" />
     <Compile Include="Roles\Chaos\Nightfall.cs" />


### PR DESCRIPTION
Allows the player to create a temporary NPC as a decoy and become a Replicant themselves, allowing them to make recon for a limited time without putting themselves at risk. If the decoy dies, the player also dies.
If a player during a Replicator ability takes damage or runs out of time, they will return safely to the NPC location.
During ability player can't shoot or using items.