### PR TITLE
Replicant Missing Inventory, Disallow picking up and dropping item, Small fixes

### DIFF
--- a/VVUP.CustomRoles/Abilities/Active/Replicator.cs
+++ b/VVUP.CustomRoles/Abilities/Active/Replicator.cs
@@ -48,7 +48,6 @@ namespace VVUP.CustomRoles.Abilities.Active
 
             Exiled.Events.Handlers.Player.Hurting -= OnPlayerHurting;
             Exiled.Events.Handlers.Player.Shooting -= OnPlayerShooting;
-            Exiled.Events.Handlers.Player.UsingItem -= OnPlayerUsingItem;
             Exiled.Events.Handlers.Player.DroppingItem -= OnPlayerDropping;
             Exiled.Events.Handlers.Player.PickingUpItem -= OnPlayerPickingUp;
             Exiled.Events.Handlers.Player.UsingItem -= OnPlayerUsingItem;

--- a/VVUP.CustomRoles/Abilities/Active/Replicator.cs
+++ b/VVUP.CustomRoles/Abilities/Active/Replicator.cs
@@ -25,12 +25,13 @@ namespace VVUP.CustomRoles.Abilities.Active
             startPos[player] = player.Position;
 
             Npc dummy = Npc.Spawn(player.Nickname, player.Role.Type, player.Position);
-            dummy.CustomInfo = player.CustomInfo;
             decoys[player] = dummy;
 
             Exiled.Events.Handlers.Player.Hurting += OnPlayerHurting;
             Exiled.Events.Handlers.Player.Shooting += OnPlayerShooting;
             Exiled.Events.Handlers.Player.UsingItem += OnPlayerUsingItem;
+            Exiled.Events.Handlers.Player.DroppingItem += OnPlayerDropping;
+            Exiled.Events.Handlers.Player.PickingUpItem += OnPlayerPickingUp;
             Exiled.Events.Handlers.Player.Dying += OnDummyDying;
         }
 
@@ -47,6 +48,9 @@ namespace VVUP.CustomRoles.Abilities.Active
 
             Exiled.Events.Handlers.Player.Hurting -= OnPlayerHurting;
             Exiled.Events.Handlers.Player.Shooting -= OnPlayerShooting;
+            Exiled.Events.Handlers.Player.UsingItem -= OnPlayerUsingItem;
+            Exiled.Events.Handlers.Player.DroppingItem -= OnPlayerDropping;
+            Exiled.Events.Handlers.Player.PickingUpItem -= OnPlayerPickingUp;
             Exiled.Events.Handlers.Player.UsingItem -= OnPlayerUsingItem;
             Exiled.Events.Handlers.Player.Dying -= OnDummyDying;
         }
@@ -67,6 +71,18 @@ namespace VVUP.CustomRoles.Abilities.Active
         }
 
         private void OnPlayerUsingItem(UsingItemEventArgs ev)
+        {
+            if (decoys.ContainsKey(ev.Player))
+                ev.IsAllowed = false;
+        }
+
+        private void OnPlayerDropping(DroppingItemEventArgs ev)
+        {
+            if (decoys.ContainsKey(ev.Player))
+                ev.IsAllowed = false;
+        }
+
+        private void OnPlayerPickingUp(PickingUpItemEventArgs ev)
         {
             if (decoys.ContainsKey(ev.Player))
                 ev.IsAllowed = false;

--- a/VVUP.CustomRoles/Roles/Chaos/Replicant.cs
+++ b/VVUP.CustomRoles/Roles/Chaos/Replicant.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Exiled.API.Enums;
 using Exiled.API.Features.Attributes;
 using Exiled.API.Features.Spawn;
 using Exiled.CustomRoles.API.Features;
@@ -18,7 +19,18 @@ namespace VVUP.CustomRoles.Roles.Chaos
         public override string Description { get; set; } = "A Chaos Insurgent that can create decoy and make recon";
         public override string CustomInfo { get; set; } = "Chaos Replicant";
         public override RoleTypeId Role { get; set; } = RoleTypeId.ChaosRifleman;
+
         public StartTeam StartTeam { get; set; } = StartTeam.Chaos;
+
+        public override List<string> Inventory { get; set; } = new()
+        {
+            $"{ItemType.ArmorCombat}",
+            $"{ItemType.Painkillers}",
+            $"{ItemType.Medkit}",
+            $"{ItemType.GunAK}",
+            $"{ItemType.KeycardChaosInsurgency}",
+        };
+
         public override SpawnProperties SpawnProperties { get; set; } = new()
         {
             Limit = 1,
@@ -29,6 +41,13 @@ namespace VVUP.CustomRoles.Roles.Chaos
                     Role = RoleTypeId.ChaosRifleman,
                     Chance = 100,
                 },
+            },
+        };
+
+        public override Dictionary<AmmoType, ushort> Ammo { get; set; } = new()
+        {
+            {
+                AmmoType.Nato762, 90
             },
         };
 

--- a/VVUP.CustomRoles/Ssss.cs
+++ b/VVUP.CustomRoles/Ssss.cs
@@ -79,7 +79,7 @@ namespace VVUP.CustomRoles
              settings.Add(new SSKeybindSetting(Plugin.Instance.Config.ReviveMistId, Plugin.Instance.Config.ReviveMistSsssText, KeyCode.B, true, false, Plugin.Instance.Config.ReviveMistHint));
              settings.Add(new SSKeybindSetting(Plugin.Instance.Config.TeleportId, Plugin.Instance.Config.TeleportSsssText, KeyCode.B, true, false, Plugin.Instance.Config.TeleportHint));
              settings.Add(new SSKeybindSetting(Plugin.Instance.Config.SoundBreakerId, Plugin.Instance.Config.SoundBreakerSsssText,KeyCode.C, true, false, Plugin.Instance.Config.SoundBreakerHint));
-             settings.Add(new SSKeybindSetting(Plugin.Instance.Config.ReplicatorId, Plugin.Instance.Config.ReplicatorSsssText,KeyCode.P, true, false, Plugin.Instance.Config.ReplicatorHint));
+             settings.Add(new SSKeybindSetting(Plugin.Instance.Config.ReplicatorId, Plugin.Instance.Config.ReplicatorSsssText,KeyCode.B, true, false, Plugin.Instance.Config.ReplicatorHint));
             return settings.ToArray();
         }
         public static void SafeAppendSsssSettings()


### PR DESCRIPTION
- Added missing inventory to Replicant role
- Changed default keybind keycode to B
- Fixed twice custom info
- Disallowed picking up and dropping items during Replicator ability